### PR TITLE
Update LaravelModelExistsServiceProvider.php

### DIFF
--- a/src/LaravelModelExistsServiceProvider.php
+++ b/src/LaravelModelExistsServiceProvider.php
@@ -9,7 +9,7 @@ class LaravelModelExistsServiceProvider extends ServiceProvider
 {
     function boot()
     {
-        Rule::macro('modelExists', function (string $modelClass, string $modelAttribute = 'id', callable $callback = null) {
+        Rule::macro('modelExists', function (string $modelClass, string $modelAttribute = 'id', ?callable $callback = null) {
             return new ModelExists($modelClass, $modelAttribute, $callback);
         });
 


### PR DESCRIPTION
Fixes warning: Implicitly marking parameter $callback as nullable is deprecated, the explicit nullable type must be used instead