### PR TITLE
Laravel 13.x Compatibility

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,11 +10,13 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 php: [7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5]
-                laravel: [6.*, 7.*, 8.*, 9.*, 10.*, 11.*, 12.*]
+                laravel: [6.*, 7.*, 8.*, 9.*, 10.*, 11.*, 12.*, 13.*]
                 dependency-version: [prefer-stable]
                 include:
                     - testbench: 10.*
-                    - laravel: 12.*
+                      laravel: 12.*
+                    - testbench: 11.*
+                      laravel: 13.*
                     - testbench: 9.*
                       laravel: 11.*
                     - testbench: 8.*
@@ -76,6 +78,16 @@ jobs:
                       laravel: 6.*
                     - php: 8.5
                       laravel: 7.*
+                    - php: 7.3
+                      laravel: 13.*
+                    - php: 7.4
+                      laravel: 13.*
+                    - php: 8.0
+                      laravel: 13.*
+                    - php: 8.1
+                      laravel: 13.*
+                    - php: 8.2
+                      laravel: 13.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "illuminate/database": "~6.0|~7.0|~8.0|~9.0|~10.0|~11.0|~12.0"
+        "illuminate/database": "~6.0|~7.0|~8.0|~9.0|~10.0|~11.0|~12.0|~13.0"
     },
     "require-dev": {
         "larapack/dd": "^1.0",
-        "orchestra/testbench": "~4.0|~5.0|~6.0|~7.0|~8.0|~9.0|~10.0",
-        "phpunit/phpunit": "^9.3|^10.0|^11.0"
+        "orchestra/testbench": "~4.0|~5.0|~6.0|~7.0|~8.0|~9.0|~10.0|~11.0",
+        "phpunit/phpunit": "^9.3|^10.0|^11.0|^12.5"
     },
     "prefer-stable": true,
     "minimum-stability": "dev",

--- a/tests/Unit/ModelExistsTest.php
+++ b/tests/Unit/ModelExistsTest.php
@@ -12,24 +12,21 @@ use Illuminate\Validation\Rule;
 
 class ModelExistsTest extends TestCase
 {
-    /** @test */
-    public function it_passes_when_model_exists()
+    public function test_it_passes_when_model_exists()
     {
         $user = User::create(['email' => 'one@example.com']);
 
         $this->assertTrue((new ModelExists(User::class))->passes('user_id', $user->id));
     }
 
-    /** @test */
-    public function it_does_not_pass_when_model_does_not_exists()
+    public function test_it_does_not_pass_when_model_does_not_exists()
     {
         User::create(['email' => 'one@example.com']);
 
         $this->assertFalse((new ModelExists(User::class))->passes('user_id', 'unexisting'));
     }
 
-    /** @test */
-    public function it_passes_when_multiple_models_exists()
+    public function test_it_passes_when_multiple_models_exists()
     {
         $user1 = User::create(['email' => 'one@example.com']);
         $user2 = User::create(['email' => 'two@example.com']);
@@ -37,16 +34,14 @@ class ModelExistsTest extends TestCase
         $this->assertTrue((new ModelExists(User::class))->passes('user_id', [$user1->id, $user2->id]));
     }
 
-    /** @test */
-    public function it_does_not_pass_when_any_of_multiple_models_does_not_exist()
+    public function test_it_does_not_pass_when_any_of_multiple_models_does_not_exist()
     {
         $user = User::create(['email' => 'one@example.com']);
 
         $this->assertTrue((new ModelExists(User::class))->passes('user_id', [$user->id, 'unexisting']));
     }
 
-    /** @test */
-    public function it_validates_with_advanced_query()
+    public function test_it_validates_with_advanced_query()
     {
         $user = User::create(['email' => 'one@example.com']);
         $adminRole = Role::create(['name' => 'admin']);
@@ -68,8 +63,7 @@ class ModelExistsTest extends TestCase
         $this->assertFalse($rule->passes('user_id', $user->id));
     }
 
-    /** @test */
-    public function it_translate_validation_message()
+    public function test_it_translate_validation_message()
     {
         Lang::addLines([
             'validation.model_exists' => 'Field :attribute has no :model with :model_attribute :value',
@@ -81,8 +75,7 @@ class ModelExistsTest extends TestCase
         $this->assertEquals('Field :attribute has no User with id unexisting', $rule->message());
     }
 
-    /** @test */
-    public function it_can_be_constructed_through_macro()
+    public function test_it_can_be_constructed_through_macro()
     {
         $this->assertTrue(Rule::modelExists(User::class) instanceof ModelExists);
     }


### PR DESCRIPTION
## Summary
- Add Laravel 13 support to `illuminate/database` dependency
- Add `orchestra/testbench` 11.x and `phpunit/phpunit` 12.5 to dev dependencies
- Add Laravel 13 to CI test matrix with testbench 11.x mapping
- Replace `/** @test */` annotations with `test_` prefixed method names for PHPUnit 12 compatibility